### PR TITLE
Ensure audio clips are valid before attempting to play them

### DIFF
--- a/source/audio.js
+++ b/source/audio.js
@@ -36,9 +36,11 @@ function audio_init(callback) {
 };
 
 function audio_play(buffer, loop) {
-	var source = audio_ctx.createBufferSource();
-	source.buffer = buffer;
-	source.loop = loop;
-	source.connect(audio_ctx.destination);
-	source.start();
+	if (buffer) {
+		var source = audio_ctx.createBufferSource();
+		source.buffer = buffer;
+		source.loop = loop;
+		source.connect(audio_ctx.destination);
+		source.start();
+	}
 };


### PR DESCRIPTION
This is to address issue #5. main.js calls terminal_write_line, which calls audio_play to play an audio clip. But this all happens before audio_init is called (which is where the audio clips are generated). The change just suppresses playing clips that haven't been initialized yet.